### PR TITLE
Add README Instructions for Setting up Gemini API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 ## Getting Started
 
+### Environment Variables
+
+Before running the server, you need to set up the following environment variable:
+
+- `GEMINI_API_KEY`: Your Google Gemini API key
+  - Create an API key at https://aistudio.google.com/
+  - Set it in your environment (~/.bashrc):
+    ```bash
+    # On Unix/macOS
+    export GEMINI_API_KEY='your-api-key'
+    ```
+
 ### Running the Development Server
 
 1. Activate your virtual environment (if using one):

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Before running the server, you need to set up the following environment variable
     # On Unix/macOS
     export GEMINI_API_KEY='your-api-key'
     ```
+  - Source your .bashrc file to apply changes:
+    ```bash
+    source ~/.bashrc
+    ```
 
 ### Running the Development Server
 


### PR DESCRIPTION
Gemini API Key is critical for running our views in the backend server (ex: POST suggestions endpoint).