### PR TITLE
Setup backend to integrate with client ios app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Before running the server, you need to set up the following environment variable
    venv\Scripts\activate      # On Windows
    ```
 
+2. Ensure the IP Address of the Machine which will be running this server is included in the `ALLOWED_HOSTS`
+of the `settings.py` file. This can be fetched by running the following command in the terminal:
+   ```bash
+   ipconfig getifaddr en0
+   ```
+
 2. Start the Django development server:
    ```bash
    python manage.py runserver 0.0.0.0:8000

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Before running the server, you need to set up the following environment variable
    venv\Scripts\activate      # On Windows
    ```
 
-2. Ensure the IP Address of the Machine which will be running this server is included in the `ALLOWED_HOSTS`
+2. Ensure the IP address of the machine which will be running this server is included in the `ALLOWED_HOSTS` list
 of the `settings.py` file. This can be fetched by running the following command in the terminal:
    ```bash
    ipconfig getifaddr en0

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Before running the server, you need to set up the following environment variable
 
 2. Start the Django development server:
    ```bash
-   python manage.py runserver
+   python manage.py runserver 0.0.0.0:8000
    ```
 
-3. The server will start at `http://127.0.0.1:8000/`
+3. The server will start at `http://0.0.0.0:8000/`
 
 Note: Make sure you have all dependencies installed and migrations applied before running the server.

--- a/photo_coach_ai_backend/settings.py
+++ b/photo_coach_ai_backend/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'django-insecure-i*hgn%07xh(_hu#0#d(*7wl=5^c%9!kafs$9*&_q&4i=qh0vz(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['10.0.0.211', 'localhost', '127.0.0.1']
+ALLOWED_HOSTS = ['localhost', '0.0.0.0', '10.0.0.211' ]
 
 # Application definition
 

--- a/photo_coach_ai_backend/settings.py
+++ b/photo_coach_ai_backend/settings.py
@@ -26,6 +26,8 @@ SECRET_KEY = 'django-insecure-i*hgn%07xh(_hu#0#d(*7wl=5^c%9!kafs$9*&_q&4i=qh0vz(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# Include IP Address of the machine running the server
+# (command: ipconfig getifaddr en0)
 ALLOWED_HOSTS = ['localhost', '0.0.0.0', '10.0.0.211' ]
 
 # Application definition

--- a/photo_coach_ai_backend/settings.py
+++ b/photo_coach_ai_backend/settings.py
@@ -26,8 +26,7 @@ SECRET_KEY = 'django-insecure-i*hgn%07xh(_hu#0#d(*7wl=5^c%9!kafs$9*&_q&4i=qh0vz(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
+ALLOWED_HOSTS = ['10.0.0.211', 'localhost', '127.0.0.1']
 
 # Application definition
 


### PR DESCRIPTION
Add instructions on how to setup the backend correctly, locally, and updated README instructions. This will allow the ios client to successfully make requests to the backend over the same network.